### PR TITLE
Addresses vulnerabilities detected on azure spring appconfiguration

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,26 @@
+ignore:
+  # Seems like another false positive: maven-wrapper is mapping to maven@3.1.0 which exposes the vulnerability, whereas it shouldn't apply
+  # since dev container and maven wrapper point to 3.8.6
+  - vulnerability: CVE-2021-26291           # (critical) fixed as of maven 3.8.1
+
+  # reactor-netty-core v 1.0.24 uses netty v4.1.82.Final for which most vulnerabilities below have been fixed, but there is a mismatch on CPEs
+  - vulnerability: CVE-2019-20444           # (critical) fixed as of netty 4.1.44
+  - vulnerability: CVE-2019-20445           # (critical) fixed as of netty 4.1.44
+  - vulnerability: CVE-2015-2156            # (high) fixed as of netty 4.1.0.Beta5
+  - vulnerability: CVE-2019-16869           # (high) fixed as of netty 4.1.42
+  - vulnerability: CVE-2021-37136           # (high) fixed as of netty 4.1.68
+  - vulnerability: CVE-2021-37137           # (high) fixed as of netty 4.1.68
+  - vulnerability: CVE-2014-3488            # (medium) fixed as of netty 3.9.2
+  - vulnerability: CVE-2021-21290           # (medium) fixed as of netty 4.1.59.Final
+  - vulnerability: CVE-2021-21295           # (medium) fixed as of netty 4.1.60.Final
+  - vulnerability: CVE-2021-21409           # (medium) fixed as of netty 4.1.61.Final
+  - vulnerability: CVE-2021-43797           # (medium) fixed as of netty 4.1.71.Final
+  - vulnerability: CVE-2022-24823           # (medium) fixed as of netty 4.1.77.Final
+
+  # spring-core exposes a remote execution vulnerability by exposing deserialization methods through HTTP invoker endpoints.
+  # More info here: https://github.com/spring-projects/spring-framework/issues/24434
+  # There is no fix for this vulnerability, other than guidance to prevent the use case from happening. The Spring team
+  # has also deprecated the classes that expose this problem to warn consumers from being exposed. Unfortunately for us,
+  # we will either add an exclusion to the vulnerability (and add mitigations to prevent risk),
+  # or will have to avoid using spring boot
+  - vulnerability: CVE-2016-1000027         # (critical) not fixed

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -2,20 +2,84 @@ ignore:
   # Seems like another false positive: maven-wrapper is mapping to maven@3.1.0 which exposes the vulnerability, whereas it shouldn't apply
   # since dev container and maven wrapper point to 3.8.6
   - vulnerability: CVE-2021-26291           # (critical) fixed as of maven 3.8.1
+    package:
+        name: maven-wrapper
 
-  # reactor-netty-core v 1.0.24 uses netty v4.1.82.Final for which most vulnerabilities below have been fixed, but there is a mismatch on CPEs
+  # reactor-netty-core v 1.0.24 uses netty v4.1.82.Final for which vulnerabilities below have been fixed, but there is a mismatch on CPEs
   - vulnerability: CVE-2019-20444           # (critical) fixed as of netty 4.1.44
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2019-20445           # (critical) fixed as of netty 4.1.44
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2015-2156            # (high) fixed as of netty 4.1.0.Beta5
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2019-16869           # (high) fixed as of netty 4.1.42
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-37136           # (high) fixed as of netty 4.1.68
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-37137           # (high) fixed as of netty 4.1.68
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2014-3488            # (medium) fixed as of netty 3.9.2
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-21290           # (medium) fixed as of netty 4.1.59.Final
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-21295           # (medium) fixed as of netty 4.1.60.Final
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-21409           # (medium) fixed as of netty 4.1.61.Final
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2021-43797           # (medium) fixed as of netty 4.1.71.Final
+    package:
+      name: reactor-netty-core
   - vulnerability: CVE-2022-24823           # (medium) fixed as of netty 4.1.77.Final
+    package:
+      name: reactor-netty-core
+
+  # reactor-netty-http v 1.0.24 uses reactor-netty-core v 1.0.24 for which vulnerabilities below have been fixed, but there is a mismatch on CPEs
+  - vulnerability: CVE-2019-20444           # (critical) fixed as of netty 4.1.44
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2019-20445           # (critical) fixed as of netty 4.1.44
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2015-2156            # (high) fixed as of netty 4.1.0.Beta5
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2019-16869           # (high) fixed as of netty 4.1.42
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-37136           # (high) fixed as of netty 4.1.68
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-37137           # (high) fixed as of netty 4.1.68
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2014-3488            # (medium) fixed as of netty 3.9.2
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-21290           # (medium) fixed as of netty 4.1.59.Final
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-21295           # (medium) fixed as of netty 4.1.60.Final
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-21409           # (medium) fixed as of netty 4.1.61.Final
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2021-43797           # (medium) fixed as of netty 4.1.71.Final
+    package:
+      name: reactor-netty-http
+  - vulnerability: CVE-2022-24823           # (medium) fixed as of netty 4.1.77.Final
+    package:
+      name: reactor-netty-http
 
   # spring-core exposes a remote execution vulnerability by exposing deserialization methods through HTTP invoker endpoints.
   # More info here: https://github.com/spring-projects/spring-framework/issues/24434

--- a/appconfigdemo/pom.xml
+++ b/appconfigdemo/pom.xml
@@ -15,12 +15,15 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
+		<!-- We have to hard-code snakeyaml version for Spring Boot 2.7.5 since they won't fix a vulnerability for 2.7.x -->
+		<!-- reference: https://github.com/spring-projects/spring-boot/issues/32221  -->
+		<snakeyaml.version>1.32</snakeyaml.version>
 	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
-			<!-- <version>2.5.12</version> -->
+			<version>2.7.5</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This PR addresses vulnerabilities found on the Azure Spring AppConfiguration package.

Specifically:

- It adds an exclusion to a vulnerability in Maven < 3.8.1 due to a mismatch on the CPE (it overlaps with Maven-wrapper)
- It adds multiple exclusions to vulnerabilities already fixed on netty (CPE overlap with reactor-netty)
- It forces the snakeyaml version to 1.32 on the project dependencies to bring forth a fix for a high severity vulnerability
- It adds an exception to CVE-2016-1000027 and explains as to why we need to live with this vulnerability